### PR TITLE
Process tree: use fork events to determine real parents

### DIFF
--- a/plugins/epan/tracee-event/packet-tracee.c
+++ b/plugins/epan/tracee-event/packet-tracee.c
@@ -2204,7 +2204,7 @@ static int dissect_tracee_json(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tr
 
     // update process tree if it's the first time seeing this event
     if (!pinfo->fd->visited)
-        process_tree_update(dissector_data->process);
+        process_tree_update(dissector_data);
 
     // this event contains a packet, dissect it
     if (dissector_data->packet_tvb != NULL)

--- a/plugins/epan/tracee-event/stats.c
+++ b/plugins/epan/tracee-event/stats.c
@@ -84,9 +84,14 @@ struct process_stat_node {
     gchar *name;
 };
 
-// Hash table mapping from stats tree address to another hash table of the nodes of the process tree indexed by PID.
-// The cleanup function must be able to free all of the saved data, and it doesn't receive any private context,
-// so the data must be global.
+struct process_tree_stats_context {
+    GHashTable *process_stat_nodes;
+    GTree *process_tree;
+};
+
+// Hash table mapping from stats tree address to the context of the stats tree.
+// The cleanup function must be able to free all of the saved data,
+// and it doesn't receive any private context, so the data must be global.
 // Because multiple stats windows can be opened at once, we cannot use a global hash table of nodes,
 // so we use an ugly hack that saves the data of each window as an entry in a global hash table indexed
 // by the stats tree data structure address, which is unique for each window.
@@ -130,20 +135,18 @@ static gchar *process_tree_get_node_name(gint32 pid, struct process_info *proces
     return node_name;
 }
 
-static void process_tree_stats_tree_add_process(stats_tree *st, gint32 pid, int parent_node_id)
+static void process_tree_stats_tree_add_process(stats_tree *st, struct process_tree_stats_context *context, gint32 pid, int parent_node_id)
 {
     guint i;
     int node_id;
     int *nodes_key;
-    GHashTable *process_stat_nodes;
     struct process_stat_node *node;
     struct process_info *process;
     GArray *children_pids;
 
-    DISSECTOR_ASSERT((process_stat_nodes = g_hash_table_lookup(stats_tree_context, &st)) != NULL);
     node = g_new0(struct process_stat_node, 1);
-    process = process_tree_get_process(pid);
-    children_pids = process_tree_get_children_pids(pid);
+    process = process_tree_get_process(context->process_tree, pid);
+    children_pids = process_tree_get_children_pids(context->process_tree, pid);
 
     node->parent_id = parent_node_id;
     node->name = process_tree_get_node_name(pid, process);
@@ -152,11 +155,11 @@ static void process_tree_stats_tree_add_process(stats_tree *st, gint32 pid, int 
 
     nodes_key = g_new(int, 1);
     *nodes_key = pid;
-    g_hash_table_insert(process_stat_nodes, nodes_key, node);
+    g_hash_table_insert(context->process_stat_nodes, nodes_key, node);
 
     // iterate through all children, adding each one to the stats tree by calling this function recursively
     for (i = 0; i < children_pids->len; i++)
-        process_tree_stats_tree_add_process(st, g_array_index(children_pids, gint32, i), node_id);
+        process_tree_stats_tree_add_process(st, context, g_array_index(children_pids, gint32, i), node_id);
     
     g_array_free(children_pids, FALSE);
 }
@@ -164,15 +167,21 @@ static void process_tree_stats_tree_add_process(stats_tree *st, gint32 pid, int 
 static void process_tree_stats_tree_init(stats_tree *st)
 {
     guint i;
-    GArray *root_pids = process_tree_get_root_pids();
-    GHashTable *process_stat_nodes = g_hash_table_new_full(g_int_hash, g_int_equal, g_free, free_process_stat_node);
+    struct process_tree_stats_context *context;
+    GArray *root_pids;
+    
+    // create the context for this process tree stats window and insert it into the global context hash table
+    context = g_new(struct process_tree_stats_context, 1);
+    context->process_stat_nodes = g_hash_table_new_full(g_int_hash, g_int_equal, g_free, free_process_stat_node);
+    context->process_tree = process_tree_construct();
     gint64 *key = g_new(gint64, 1);
     *key = (gint64)st;
+    g_hash_table_insert(stats_tree_context, key, context);
 
-    g_hash_table_insert(stats_tree_context, key, process_stat_nodes);
-
+    // generate a list of process tree roots and create the stats tree from them
+    root_pids = process_tree_get_root_pids(context->process_tree);
     for (i = 0; i < root_pids->len; i++)
-        process_tree_stats_tree_add_process(st, g_array_index(root_pids, gint32, i), 0);
+        process_tree_stats_tree_add_process(st, context, g_array_index(root_pids, gint32, i), 0);
     
     g_array_free(root_pids, FALSE);
 }
@@ -185,16 +194,16 @@ static tap_packet_status process_tree_stats_tree_packet(stats_tree* st, packet_i
     epan_dissect_t* edt _U_, const void* p, tap_flags_t flags _U_)
 #endif
 {
+    struct process_tree_stats_context *context;
     struct process_stat_node *node;
     struct tracee_dissector_data *data = (struct tracee_dissector_data *)p;
-    GHashTable *process_stat_nodes;
 
-    DISSECTOR_ASSERT((process_stat_nodes = g_hash_table_lookup(stats_tree_context, &st)) != NULL);
+    DISSECTOR_ASSERT((context = g_hash_table_lookup(stats_tree_context, &st)) != NULL);
 
     if (data->process == NULL || data->process->host_pid == 0)
         return TAP_PACKET_DONT_REDRAW;
     
-    DISSECTOR_ASSERT((node = g_hash_table_lookup(process_stat_nodes, &data->process->host_pid)) != NULL);
+    DISSECTOR_ASSERT((node = g_hash_table_lookup(context->process_stat_nodes, &data->process->host_pid)) != NULL);
     tick_stat_node(st, node->name, node->parent_id, TRUE);
 
     return TAP_PACKET_REDRAW;
@@ -202,10 +211,12 @@ static tap_packet_status process_tree_stats_tree_packet(stats_tree* st, packet_i
 
 static void process_tree_stats_tree_cleanup(stats_tree *st)
 {
-    GHashTable *process_stat_nodes;
+    struct process_tree_stats_context *context;
 
-    DISSECTOR_ASSERT((process_stat_nodes = g_hash_table_lookup(stats_tree_context, &st)) != NULL);
-    g_hash_table_destroy(process_stat_nodes);
+    DISSECTOR_ASSERT((context = g_hash_table_lookup(stats_tree_context, &st)) != NULL);
+
+    g_hash_table_destroy(context->process_stat_nodes);
+    g_tree_destroy(context->process_tree);
     g_hash_table_remove(stats_tree_context, &st);
 }
 

--- a/plugins/epan/tracee-event/tracee.h
+++ b/plugins/epan/tracee-event/tracee.h
@@ -58,10 +58,11 @@ proto_item *proto_tree_add_string_wanted(proto_tree *tree, int hfindex, tvbuff_t
 proto_item *proto_tree_add_boolean_wanted(proto_tree *tree, int hfindex, tvbuff_t *tvb, gint start, gint length, guint32 value);
 
 void process_tree_init(void);
-void process_tree_update(struct process_info *process);
-GArray *process_tree_get_root_pids(void);
-struct process_info *process_tree_get_process(gint32 pid);
-GArray *process_tree_get_children_pids(gint32 pid);
+void process_tree_update(struct tracee_dissector_data *data);
+GTree *process_tree_construct(void);
+GArray *process_tree_get_root_pids(GTree *process_tree);
+struct process_info *process_tree_get_process(GTree *process_tree, gint32 pid);
+GArray *process_tree_get_children_pids(GTree *process_tree, gint32 pid);
 
 void register_tracee_enrichments(int proto);
 void register_tracee_statistics(void);


### PR DESCRIPTION
If we see a process fork event, we use the data to override any parent-child relationship we see for the created process. As a side effect, the tree is generated on demand and not on the fly.

This closes #13.