### PR TITLE
Standard process tree now supports filters

### DIFF
--- a/plugins/epan/tracee-event/tracee.h
+++ b/plugins/epan/tracee-event/tracee.h
@@ -64,10 +64,8 @@ gchar *enrichments_get_security_socket_bind_connect_description(packet_info *pin
 void process_tree_init(void);
 void process_tree_update(struct tracee_dissector_data *data);
 GTree *process_tree_construct(void);
-GArray *process_tree_get_root_pids(GTree *process_tree);
 struct process_info *process_tree_get_process(GTree *process_tree, gint32 pid);
 struct process_info *process_tree_get_parent(GTree *process_tree, gint32 pid);
-GArray *process_tree_get_children_pids(GTree *process_tree, gint32 pid);
 
 void register_tracee_enrichments(int proto);
 void register_tracee_statistics(void);


### PR DESCRIPTION
By constructing the tree from the leafs like the files and network trees, we can build only "hot paths" according to the display filter.