### PR TITLE
Add support for various types

### DIFF
--- a/plugins/epan/tracee-event/tracee.h
+++ b/plugins/epan/tracee-event/tracee.h
@@ -32,7 +32,8 @@ enum field_type {
     FIELD_TYPE_INT64,
     FIELD_TYPE_UINT64,
     FIELD_TYPE_STRING,
-    FIELD_TYPE_BOOLEAN
+    FIELD_TYPE_BOOLEAN,
+    FIELD_TYPE_DOUBLE,
 };
 
 struct field_value {
@@ -44,6 +45,7 @@ struct field_value {
         guint64 val_uint64;
         gchar *val_string;
         gboolean val_boolean;
+        double val_double;
     } val;
 };
 
@@ -59,6 +61,7 @@ proto_item *proto_tree_add_int64_wanted(proto_tree *tree, int hfindex, tvbuff_t 
 proto_item *proto_tree_add_uint64_wanted(proto_tree *tree, int hfindex, tvbuff_t *tvb, gint start, gint length, guint64 value);
 proto_item *proto_tree_add_string_wanted(proto_tree *tree, int hfindex, tvbuff_t *tvb, gint start, gint length, const char* value);
 proto_item *proto_tree_add_boolean_wanted(proto_tree *tree, int hfindex, tvbuff_t *tvb, gint start, gint length, guint32 value);
+proto_item *proto_tree_add_double_wanted(proto_tree *tree, int hfindex, tvbuff_t *tvb, gint start, gint length, double value);
 
 gchar *enrichments_get_security_socket_bind_connect_description(packet_info *pinfo, const gchar *verb);
 

--- a/plugins/epan/tracee-event/wanted_fields.c
+++ b/plugins/epan/tracee-event/wanted_fields.c
@@ -139,3 +139,9 @@ proto_item *proto_tree_add_boolean_wanted(proto_tree *tree, int hfindex, tvbuff_
     handle_wanted_field(hfindex, value, FIELD_TYPE_BOOLEAN, val_boolean);
     return proto_tree_add_boolean(tree, hfindex, tvb, start, length, value);
 }
+
+proto_item *proto_tree_add_double_wanted(proto_tree *tree, int hfindex, tvbuff_t *tvb, gint start, gint length, double value)
+{
+    handle_wanted_field(hfindex, value, FIELD_TYPE_DOUBLE, val_double);
+    return proto_tree_add_double(tree, hfindex, tvb, start, length, value);
+}


### PR DESCRIPTION
All of the types are syscall arguments.
Most of them are pointers in string form.
One was a double, so support was added for double dissection. One was an int, and one was an int array so support was added in the form of a complex argument.