### PR TITLE
Fix dissection error in dynamic_code_loading

### DIFF
--- a/plugins/epan/tracee-event/process_tree.c
+++ b/plugins/epan/tracee-event/process_tree.c
@@ -31,7 +31,7 @@ static struct container_info *dup_container_info(const struct container_info *co
 
 void process_tree_update(struct tracee_dissector_data *data)
 {
-    gint *fork_child_pid, *fork_child_tid;
+    const gint *fork_child_pid, *fork_child_tid;
     gint *pid_key, *pid_val;
     struct process_info *process;
 

--- a/plugins/epan/tracee-event/tracee.h
+++ b/plugins/epan/tracee-event/tracee.h
@@ -67,10 +67,10 @@ struct field_value {
 };
 
 void register_wanted_field(const gchar *filter_name);
-wmem_array_t *wanted_field_get(const gchar *filter_name);
-struct field_value *wanted_field_get_one(const gchar *filter_name);
+const wmem_array_t *wanted_field_get(const gchar *filter_name);
+const struct field_value *wanted_field_get_one(const gchar *filter_name);
 const gchar *wanted_field_get_str(const gchar *filter_name);
-gint *wanted_field_get_int(const gchar *filter_name);
+const gint *wanted_field_get_int(const gchar *filter_name);
 
 proto_item *proto_tree_add_int_wanted(proto_tree *tree, int hfindex, tvbuff_t *tvb, gint start, gint length, gint32 value);
 proto_item *proto_tree_add_uint_wanted(proto_tree *tree, int hfindex, tvbuff_t *tvb, gint start, gint length, guint32 value);

--- a/plugins/epan/tracee-event/wanted_fields.c
+++ b/plugins/epan/tracee-event/wanted_fields.c
@@ -26,24 +26,24 @@ void register_wanted_field(const gchar *filter_name)
     wmem_map_insert(wanted_fields, key, NULL);
 }
 
-wmem_array_t *wanted_field_get(const gchar *filter_name)
+const wmem_array_t *wanted_field_get(const gchar *filter_name)
 {
     return wmem_map_lookup(wanted_field_values, filter_name);
 }
 
-struct field_value *wanted_field_get_one(const gchar *filter_name)
+const struct field_value *wanted_field_get_one(const gchar *filter_name)
 {
-    wmem_array_t *values = wanted_field_get(filter_name);
+    const wmem_array_t *values = wanted_field_get(filter_name);
 
-    if (values && wmem_array_get_count(values) >= 1)
-        return *((struct field_value **)wmem_array_index(values, 0));
+    if (values && wmem_array_get_count((wmem_array_t *)values) >= 1)
+        return *((struct field_value **)wmem_array_index((wmem_array_t *)values, 0));
     
     return NULL;
 }
 
 const gchar *wanted_field_get_str(const gchar *filter_name)
 {
-    struct field_value *fv;
+    const struct field_value *fv;
 
     if ((fv = wanted_field_get_one(filter_name)) == NULL)
         return NULL;
@@ -52,9 +52,9 @@ const gchar *wanted_field_get_str(const gchar *filter_name)
     return fv->val.val_string;
 }
 
-gint *wanted_field_get_int(const gchar *filter_name)
+const gint *wanted_field_get_int(const gchar *filter_name)
 {
-    struct field_value *fv;
+    const struct field_value *fv;
 
     if ((fv = wanted_field_get_one(filter_name)) == NULL)
         return NULL;


### PR DESCRIPTION
`alert` field of `mem_prot_alert` is not a string if parse-arguments is disabled